### PR TITLE
Fix payment data month format and export credential/payment types

### DIFF
--- a/src/types/CredentialTypes.ts
+++ b/src/types/CredentialTypes.ts
@@ -1,4 +1,4 @@
-type CredentialsType = {
+export type CredentialsType = {
   USERNAME: string;
   PASSWORD: string;
 };

--- a/src/types/PaymentTypes.ts
+++ b/src/types/PaymentTypes.ts
@@ -1,4 +1,4 @@
-type PaymentType = {
+export type PaymentType = {
   NAME: string;
   COUNTRY: string;
   CITY: string;

--- a/src/utils/Credentials.ts
+++ b/src/utils/Credentials.ts
@@ -1,3 +1,5 @@
+import type { CredentialsType } from '../types/CredentialTypes';
+
 export const Credentials: CredentialsType = {
   USERNAME: 'username',
   PASSWORD: 'password',

--- a/src/utils/Payment.ts
+++ b/src/utils/Payment.ts
@@ -1,10 +1,12 @@
 import { faker } from '@faker-js/faker';
+import type { PaymentType } from '../types/PaymentTypes';
 
 export const Payment: PaymentType = {
   NAME: faker.person.fullName(),
   COUNTRY: faker.location.country(),
   CITY: faker.location.city(),
   CREDIT_CARD: faker.finance.creditCardNumber(),
-  MONTH: faker.date.month(),
+  // Use a numeric month to match the purchase form's expected format
+  MONTH: faker.number.int({ min: 1, max: 12 }).toString(),
   YEAR: '2030',
 };


### PR DESCRIPTION
## Summary
- generate numeric month for payment details to align with checkout form expectations
- export credential and payment types and import them where used

## Testing
- `npm run lint`
- `npx playwright test --reporter=line` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1105/chrome-linux/chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6895098f82c4832fb268f9743a8d4add